### PR TITLE
Update MetaParser.java

### DIFF
--- a/main/src/com/google/refine/expr/MetaParser.java
+++ b/main/src/com/google/refine/expr/MetaParser.java
@@ -65,7 +65,7 @@ abstract public class MetaParser {
 //    final static private Var CLOJURE_EVAL = RT.var("clojure.core", "eval");
     
     static {
-        registerLanguageParser("grel", "Google Refine Expression Language (GREL)", new LanguageSpecificParser() {
+        registerLanguageParser("grel", "General Refine Expression Language (GREL)", new LanguageSpecificParser() {
             
             @Override
             public Evaluable parse(String s) throws ParsingException {


### PR DESCRIPTION
Changed GREL to _General Refine Expression Language_ as agreed in 2013 when drafting _Using OpenRefine_

Will be nice to have it part of the 2.6 official release to completed the change of branding.
